### PR TITLE
Added limit power limit. Still some bugs with naming

### DIFF
--- a/custom_components/growatt_local/API/device_type/inverter_120.py
+++ b/custom_components/growatt_local/API/device_type/inverter_120.py
@@ -87,7 +87,6 @@ from .base import (
 
 MAXIMUM_DATA_LENGTH_120 = 100
 
-
 def model(registers) -> str:
     mo = (registers[0] << 16) + registers[1]
     return "A{:X} B{:X} D{:X} T{:X} P{:X} U{:X} M{:X} S{:X}".format(
@@ -100,7 +99,6 @@ def model(registers) -> str:
         (mo & 0x000000F0) >> 4,
         (mo & 0x0000000F)
     )
-
 
 HOLDING_REGISTERS_120: tuple[GrowattDeviceRegisters, ...] = (
     GrowattDeviceRegisters(
@@ -317,3 +315,13 @@ INPUT_REGISTERS_120: tuple[GrowattDeviceRegisters, ...] = (
         name=ATTR_OUTPUT_REACTIVE_ENERGY_TOTAL, register=236, value_type=float, length=2,
     ),
 )
+
+def get_power_limit(self) -> int:
+    """Read the inverter power limit (0–100%) from holding register 3."""
+    return self.read_register(3)
+
+def set_power_limit(self, value: int) -> None:
+    """Write a new inverter power limit (0–100%) to holding register 3."""
+    if not 0 <= value <= 100:
+        raise ValueError("Power limit must be between 0 and 100")
+    self.write_register(3, value)

--- a/custom_components/growatt_local/API/growatt.py
+++ b/custom_components/growatt_local/API/growatt.py
@@ -278,6 +278,26 @@ class GrowattDevice:
     def close(self):
         self.modbus.close()
 
+
+
+    async def get_power_limit(self) -> int:
+        result = await self.modbus.read_holding_registers(3, 1, slave=1)
+
+        if not result or not isinstance(result, dict):
+            _LOGGER.warning("MODBUS result invalid or unexpected format: %s", result)
+            return 0
+
+        value = result.get(3, 0)
+        _LOGGER.debug("Decoded power limit value: %s", value)
+        return value
+
+
+
+    async def set_power_limit(self, value: int) -> None:
+        await self.modbus.write_register(3, value, self.slave)
+
+
+
     async def get_device_info(self) -> GrowattDeviceInfo:
         return await self.modbus.get_device_info(self.holding_register, self.max_length, self.slave)
 

--- a/custom_components/growatt_local/__init__.py
+++ b/custom_components/growatt_local/__init__.py
@@ -281,6 +281,13 @@ class GrowattLocalCoordinator(DataUpdateCoordinator):
 
         if status:
             data["status"] = status
+        
+        try:
+            limit = await self.growatt_api.get_power_limit()
+            _LOGGER.debug("Fetched current power limit from inverter: %s", limit)
+            data["power_limit"] = limit
+        except Exception as e:
+            _LOGGER.warning("Failed to retrieve power limit: %s", e)
 
         return data
 

--- a/custom_components/growatt_local/const.py
+++ b/custom_components/growatt_local/const.py
@@ -40,4 +40,4 @@ DEFAULT_NAME = "Growatt Modbus"
 
 DOMAIN = "growatt_local"
 
-PLATFORMS = [Platform.SENSOR, Platform.SWITCH]
+PLATFORMS = [Platform.SENSOR, Platform.SWITCH, Platform.NUMBER]

--- a/custom_components/growatt_local/manifest.json
+++ b/custom_components/growatt_local/manifest.json
@@ -4,7 +4,7 @@
     "config_flow": true,
     "documentation": "https://github.com/WouterTuinstra/homeassistant-growatt-local-modbus",
     "issue_tracker": "https://github.com/WouterTuinstra/Homeassistant-Growatt-Local-Modbus/issues",
-    "dependencies": ["sun"],
+    "dependencies": ["sun","number"],
     "requirements": ["pymodbus>=3.8.3"],
     "codeowners": ["@WouterTuinstra"],
     "iot_class": "local_polling",

--- a/custom_components/growatt_local/number.py
+++ b/custom_components/growatt_local/number.py
@@ -1,0 +1,60 @@
+from homeassistant.components.number import (
+    NumberEntity,
+    NumberEntityDescription
+)
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from . import GrowattLocalCoordinator
+from .const import DOMAIN
+
+INVERTER_POWER_LIMIT_DESCRIPTION = NumberEntityDescription(
+    key="power_limit",
+    name="Power Limit",
+    native_unit_of_measurement="%",
+    native_min_value=0,
+    native_max_value=100,
+    native_step=1,
+    icon="mdi:transmission-tower-export",
+)
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    coordinator: GrowattLocalCoordinator = hass.data[DOMAIN][entry.data["serial_number"]]
+    async_add_entities([
+        InverterPowerLimitEntity(coordinator, entry, INVERTER_POWER_LIMIT_DESCRIPTION)
+    ])
+    
+class InverterPowerLimitEntity(CoordinatorEntity, NumberEntity):
+    def __init__(self, coordinator, entry, description):
+        super().__init__(coordinator)
+        self.coordinator = coordinator
+        self.config_entry = entry
+        self.entity_description = description
+        self._attr_has_entity_name = True
+        self._attr_suggested_object_id = f"{entry.title.lower()}_{description.key}"
+        self._attr_unique_id = f"{entry.entry_id}_{description.key}"
+
+    @property
+    def native_value(self) -> int:
+        return self.coordinator.data.get("power_limit", 0)
+
+    async def async_set_native_value(self, value: float) -> None:
+        await self.coordinator.growatt_api.set_power_limit(int(value))
+        await self.coordinator.async_request_refresh()
+
+    @property
+    def device_info(self):
+        return {
+            "identifiers": {
+                (DOMAIN, self.config_entry.data["serial_number"])
+            },
+            "name": self.config_entry.title,
+            "manufacturer": "Growatt",
+            "model": self.config_entry.data.get("model", "Unknown"),
+        }


### PR DESCRIPTION
Entity name somehow reflects the model and not the devicename as all other entities.
Fully done using chatgpt by training it and tellings it what I want and feeding it error logs. Extensive testing. Cannot get that name fixed. Slider works properly. All validated using the modbus poll application.

validated against a Growatt MIN4200TL-X using a TCP connection over a waveshare adapter.